### PR TITLE
Add basic test menu and course generation test page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ function App() {
             <Route path="/elims">
               <Eliminations />
             </Route>
-            <Route path="/tests">
+            <Route path="/tests/coursegen">
               <CourseGenerator />
             </Route>
           </IonRouterOutlet>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,8 @@ import "@ionic/react/css/display.css";
 import "./theme.css";
 import { Seeding } from "./pages/Seeding";
 import { Eliminations } from "./pages/Eliminations";
-import CourseGenerator from "./pages/CourseGenerator";
+import CourseGenerator from "./pages/tests/CourseGenerator";
+import TestPage from "./pages/Test";
 
 setupIonicReact();
 
@@ -51,7 +52,10 @@ function App() {
             <Route path="/elims">
               <Eliminations />
             </Route>
-            <Route path="/tests/coursegen">
+            <Route path="/tests">
+              <TestPage />
+            </Route>
+            <Route path="/coursetest">
               <CourseGenerator />
             </Route>
           </IonRouterOutlet>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import "@ionic/react/css/display.css";
 import "./theme.css";
 import { Seeding } from "./pages/Seeding";
 import { Eliminations } from "./pages/Eliminations";
+import CourseGenerator from "./pages/CourseGenerator";
 
 setupIonicReact();
 
@@ -49,6 +50,9 @@ function App() {
             </Route>
             <Route path="/elims">
               <Eliminations />
+            </Route>
+            <Route path="/tests">
+              <CourseGenerator />
             </Route>
           </IonRouterOutlet>
         </IonSplitPane>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,7 @@ import {
   IonTitle,
   IonToolbar,
 } from "@ionic/react";
-import { trophy } from "ionicons/icons";
+import { cog, trophy } from "ionicons/icons";
 import { useState } from "react";
 import { css } from "@emotion/css";
 
@@ -18,6 +18,7 @@ import { prefersDarkTheme } from "../darkTheme";
 import { useIonRouter } from "@ionic/react";
 
 interface Props {
+  showTestMenu?: boolean;
   showLeaderboard?: boolean;
   title?: string;
   currentRound?: number;
@@ -31,7 +32,7 @@ const leaderboardLabel = css`
   }
 `;
 
-export function Header({ showLeaderboard, title, currentRound }: Props) {
+export function Header({ showTestMenu, showLeaderboard, title, currentRound }: Props) {
   const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
   const router = useIonRouter();
 
@@ -61,6 +62,18 @@ export function Header({ showLeaderboard, title, currentRound }: Props) {
               isOpen={isLeaderboardOpen}
               onClose={() => setIsLeaderboardOpen(false)}
             />
+          </>
+        )}
+        {showTestMenu && (
+          <>
+            <IonButtons slot="end">
+              <IonButton onClick={() => router.push("/tests")}>
+                <IonLabel className={leaderboardLabel}>
+                  Test Menu
+                </IonLabel>
+                <IonIcon icon={cog} />
+              </IonButton>
+            </IonButtons>
           </>
         )}
       </IonToolbar>

--- a/src/data/course_data/wiiCourseData.ts
+++ b/src/data/course_data/wiiCourseData.ts
@@ -98,7 +98,7 @@ const wiiCourseData: Course[] = [{
   },
   {
     name: "N64 Sherbet Land",
-    degreeOfDifficulty: 4,
+    degreeOfDifficulty: 5,
     platform: Platform.Wii
   },
   {

--- a/src/pages/CourseGenerator.tsx
+++ b/src/pages/CourseGenerator.tsx
@@ -7,12 +7,15 @@ import {
   IonCardHeader,
   IonCardTitle,
   IonContent,
+  IonHeader,
   IonIcon,
   IonInput,
   IonItem,
   IonLabel,
+  IonModal,
   IonNavLink,
   IonPage,
+  IonRange,
   IonRouterLink,
   IonSelect,
   IonSelectOption,
@@ -20,23 +23,16 @@ import {
   useIonRouter,
 } from "@ionic/react";
 import { useState } from "react";
+import { generateCourseSelection } from "../algorithms";
 import { Header } from "../components/Header";
+import Course from "../types/Course";
 import { Platform } from "../types/Platform";
 
 const content = css`
-  display: grid;
-  grid-template-rows: 200px 1fr;
-  place-items: center;
-  width: 100vw;
-  margin-top: 20px;
-
-  & > .card-wrapper {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-  }
+display: flex;
+margin: 0 auto;
+justify-content: center;
+width: 100%;
 `;
 
 const card = css`
@@ -49,33 +45,81 @@ const card = css`
   }
 `;
 
-const listing = css`
-  font-size: 32px;
-  --inner-padding-top: 12px;
-  --inner-padding-bottom: 12px;
-  --inner-padding-start: 16px;
-  --inner-padding-end: 16px;
+const modal = css`
+--min-width: 800px;
+--height: 32em;
 `;
-
 
 const CourseGenerator = () => {
 
   const [platform, setPlatform] = useState(Platform.NONE)
   const [plat, setPlat] = useState(platform)
+  const [threshold, setThreshold] = useState(4)
+
+  const [generatedCoursesModal, setGeneratedCoursesModal] = useState(false)
+  const showGeneratedCoursesModal = () => setGeneratedCoursesModal(true)
+  const hideGeneratedCoursesModal = () => setGeneratedCoursesModal(false)
+
+  const [courses, setCourses] = useState<Course[]>([])
+
+  const handleGenerateSelection = () => {
+    setCourses(generateCourseSelection(platform, threshold, 4))
+    showGeneratedCoursesModal()
+  }
 
   return (
     <IonPage>
       <Header />
       <IonContent>
-        <div>
+        <div className={content}>
+          <IonModal isOpen={generatedCoursesModal} className={modal} onDidDismiss={hideGeneratedCoursesModal}>
+            <IonContent>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  height: "100%",
+                  paddingBottom: 24,
+                }}
+              >
+                <IonCardHeader>
+                  <IonCardTitle><strong>Generated Courses</strong></IonCardTitle>
+                </IonCardHeader>
+                {
+                  courses.map(course => {
+                      return (
+                        <IonItem>
+                          <IonLabel>{course.name}</IonLabel>
+                          <IonLabel>Degree of Difficulty: </IonLabel>
+                          <IonLabel>{course.degreeOfDifficulty}</IonLabel>
+                        </IonItem>
+                      )
+                    })
+                }
+              </div>
+            </IonContent>
+          </IonModal>
           <IonCard className={card}>
             <IonCardContent>
               <IonCardHeader>
-                <IonCardTitle><strong>Create a Tournament</strong></IonCardTitle>
+                <IonCardTitle><strong>Test Course Generation</strong></IonCardTitle>
               </IonCardHeader>
               <IonItem>
                 <IonLabel>Threshold</IonLabel>
-                <IonInput
+
+                <IonRange
+                  min={4}
+                  max={20}
+                  snaps={true}
+                  pin
+                  value={threshold}
+                  onIonChange={(ev) => {
+                    setThreshold(ev.detail.value as number);
+                  }}
+                >
+                  <IonLabel slot="start">4</IonLabel>
+                  <IonLabel slot="end">20</IonLabel>
+                </IonRange>
               </IonItem>
               <IonItem>
                 <IonLabel>Platform</IonLabel>
@@ -99,8 +143,8 @@ const CourseGenerator = () => {
                   size="default"
                   style={{ margin: "auto" }}
                   color="success"
-                  onClick={onSubmit}
-                  disabled={!allEntered}
+                  onClick={handleGenerateSelection}
+                  disabled={platform == Platform.NONE}
                 >
                   Generate Courses
                 </IonButton>

--- a/src/pages/CourseGenerator.tsx
+++ b/src/pages/CourseGenerator.tsx
@@ -89,9 +89,8 @@ const CourseGenerator = () => {
                   courses.map(course => {
                       return (
                         <IonItem>
-                          <IonLabel>{course.name}</IonLabel>
-                          <IonLabel>Degree of Difficulty: </IonLabel>
-                          <IonLabel>{course.degreeOfDifficulty}</IonLabel>
+                          <IonLabel><strong>{course.name}</strong></IonLabel>
+                          <IonLabel>Degree of Difficulty: <strong>{course.degreeOfDifficulty}</strong></IonLabel>
                         </IonItem>
                       )
                     })

--- a/src/pages/CourseGenerator.tsx
+++ b/src/pages/CourseGenerator.tsx
@@ -1,0 +1,118 @@
+import { css } from "@emotion/css";
+import {
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonContent,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonNavLink,
+  IonPage,
+  IonRouterLink,
+  IonSelect,
+  IonSelectOption,
+  IonTitle,
+  useIonRouter,
+} from "@ionic/react";
+import { useState } from "react";
+import { Header } from "../components/Header";
+import { Platform } from "../types/Platform";
+
+const content = css`
+  display: grid;
+  grid-template-rows: 200px 1fr;
+  place-items: center;
+  width: 100vw;
+  margin-top: 20px;
+
+  & > .card-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
+const card = css`
+  width: 600px;
+  max-width: calc(100vw - 40px);
+  & > .center {
+    height: 100px;
+    display: grid;
+    place-items: center;
+  }
+`;
+
+const listing = css`
+  font-size: 32px;
+  --inner-padding-top: 12px;
+  --inner-padding-bottom: 12px;
+  --inner-padding-start: 16px;
+  --inner-padding-end: 16px;
+`;
+
+
+const CourseGenerator = () => {
+
+  const [platform, setPlatform] = useState(Platform.NONE)
+  const [plat, setPlat] = useState(platform)
+
+  return (
+    <IonPage>
+      <Header />
+      <IonContent>
+        <div>
+          <IonCard className={card}>
+            <IonCardContent>
+              <IonCardHeader>
+                <IonCardTitle><strong>Create a Tournament</strong></IonCardTitle>
+              </IonCardHeader>
+              <IonItem>
+                <IonLabel>Threshold</IonLabel>
+                <IonInput
+              </IonItem>
+              <IonItem>
+                <IonLabel>Platform</IonLabel>
+                <IonSelect
+                  value={plat}
+                  placeholder="Platform"
+                  onIonChange={(ev) => {
+                    setPlatform(ev.detail.value);
+                    setPlat(ev.detail.value);
+                  }}
+                >
+                  {Object.values(Platform)
+                    .filter((platOpt) => !(platOpt === Platform.NONE))
+                    .map((platOption, i) => (
+                      <IonSelectOption key={i} value={platOption}>{platOption}</IonSelectOption>
+                    ))}
+                </IonSelect>
+              </IonItem>
+              <IonItem>
+                <IonButton
+                  size="default"
+                  style={{ margin: "auto" }}
+                  color="success"
+                  onClick={onSubmit}
+                  disabled={!allEntered}
+                >
+                  Generate Courses
+                </IonButton>
+              </IonItem>
+            </IonCardContent>
+          </IonCard>
+        </div>
+      </IonContent>
+    </IonPage>
+  )
+
+
+}
+
+export default CourseGenerator

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -152,7 +152,7 @@ export function Create() {
 
   return (
     <IonPage>
-      <Header />
+      <Header showTestMenu={true}/>
       <IonContent>
         <div className={wrapper}>
           <IonCard className={card}>

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,0 +1,83 @@
+import { css } from "@emotion/css";
+import {
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonModal,
+  IonNavLink,
+  IonPage,
+  IonRange,
+  IonRouterLink,
+  IonSelect,
+  IonSelectOption,
+  IonTitle,
+  useIonRouter,
+} from "@ionic/react";
+import { useState } from "react";
+import { Header } from "../components/Header";
+
+const content = css`
+display: flex;
+margin: 0 auto;
+justify-content: center;
+width: 100%;
+`;
+
+const card = css`
+  width: 600px;
+  max-width: calc(100vw - 40px);
+  & > .center {
+    height: 100px;
+    display: grid;
+    place-items: center;
+  }
+`;
+
+const modal = css`
+--min-width: 800px;
+--height: 32em;
+`;
+
+const TestPage = () => {
+
+  const router = useIonRouter();
+
+  return (
+      <IonPage>
+        <Header />
+        <IonContent>
+          <div className={content}>
+            <IonCard className={card}>
+              <IonCardContent>
+                <IonCardHeader>
+                  <IonCardTitle><strong>Test Menu</strong></IonCardTitle>
+                </IonCardHeader>
+                <IonItem>
+                  <IonButton
+                    size="default"
+                    style={{ margin: "auto" }}
+                    color="success"
+                    onClick={() => router.push("/coursetest")}
+                  >
+                    Generate Courses Test
+                  </IonButton>
+                </IonItem>
+              </IonCardContent>
+            </IonCard>
+          </div>
+        </IonContent>
+      </IonPage>
+    )
+
+}
+
+export default TestPage

--- a/src/pages/tests/CourseGenerator.tsx
+++ b/src/pages/tests/CourseGenerator.tsx
@@ -23,10 +23,11 @@ import {
   useIonRouter,
 } from "@ionic/react";
 import { useState } from "react";
-import { generateCourseSelection } from "../algorithms";
-import { Header } from "../components/Header";
-import Course from "../types/Course";
-import { Platform } from "../types/Platform";
+import { generateCourseSelection } from "../../algorithms";
+import { Header } from "../../components/Header";
+import Course from "../../types/Course";
+import { Platform } from "../../types/Platform";
+
 
 const content = css`
 display: flex;
@@ -84,6 +85,7 @@ const CourseGenerator = () => {
               >
                 <IonCardHeader>
                   <IonCardTitle><strong>Generated Courses</strong></IonCardTitle>
+                  <IonLabel>Chosen Threshold: {threshold}</IonLabel>
                 </IonCardHeader>
                 {
                   courses.map(course => {


### PR DESCRIPTION
## Feature Description

- adds a test menu accessible via the create page (can be moved or hidden), ideally to add more UI tests in the future
- adds a test page for testing the course generation algorithm

## Testing Instructions
- test the test page (lol)
## Required local store changes (If Needed)
`no storage changes necessary`
## PR Checklist
- [ ] Feature works on Firefox and Chrome
- [ ] Feature works on mobile
- [ ] JS version param updated/cache busting (if needed)
