### PR TITLE
Fix Tooltip to only show when disabled

### DIFF
--- a/src/pages/Seeding.tsx
+++ b/src/pages/Seeding.tsx
@@ -86,7 +86,7 @@ export function Seeding() {
               Continue to Elims
             </IonButton>
           </div>
-          {canContinue() &&
+          {!canContinue() && 
             <ReactTooltip
               id="continueTip"
               type={prefersDarkTheme() ? "light" : "dark"}

--- a/src/pages/Seeding.tsx
+++ b/src/pages/Seeding.tsx
@@ -105,7 +105,7 @@ export function Seeding() {
               Continue to Elims
             </IonButton>
           </div>
-          {!canContinue() && 
+          {!canContinue() && (
             <ReactTooltip
               id="continueTip"
               type={prefersDarkTheme() ? "light" : "dark"}


### PR DESCRIPTION
Bug occurred from tooltip only rendering when `canContinue()` was true, changed it to only render when `!canContinue()`