### PR TITLE
Use a Normal Distribution when randomly selecting courses for course generation

### DIFF
--- a/src/algorithms.ts
+++ b/src/algorithms.ts
@@ -6,7 +6,7 @@ import Setup from "./types/Setup";
 import { chunked, range, groupby } from "itertools";
 import Course from "./types/Course";
 import { Platform } from "./types/Platform";
-import COURSE_DATA, { getRandomThreshold } from "./data/courseData";
+import COURSE_DATA, { getRandomCourse } from "./data/courseData";
 import { switchDLCCutoff } from "./data/course_data/switchCourseData";
 import { useStore } from "./store";
 import RoundResult from "./types/RoundResult";
@@ -252,15 +252,6 @@ export function uploadRoundResult(round: Round, partsPerMatch: number, partsInMa
   }
 }
 
-function getRandomCourseFromPool(coursePool: Course[], diffThreshold: number, chosenCourses: Course[]): Course {
-  const availableCourses = coursePool.filter((course: Course) => course.degreeOfDifficulty == diffThreshold && !chosenCourses.some((c) => c.name === course.name));
-  if (availableCourses.length > 0){
-    // TODO: remove lol
-    return availableCourses[Math.floor( Math.random() * availableCourses.length)];
-  }
-  return coursePool[Math.floor(Math.random() * coursePool.length)];
-}
-
 /**
  * A function that generates courses randomly for a given platform using a difficulty threshold to select courses semi-randomly
  * @param platform - the platform you are playing on
@@ -282,9 +273,7 @@ export const generateCourseSelection = (
   }
 
   for(let courseChoice = 0; courseChoice < racesPerMatch; courseChoice++){
-    // cycle thresholds in groups of 4 for now, but this should be extendable in the future
-    const threshold = Math.round(Math.random() * 5);
-    courseSelection.push(getRandomCourseFromPool(coursesToChoose, threshold, courseSelection));
+    courseSelection.push(getRandomCourse(platform, courseSelection, dlc));
   }
 
   return courseSelection;

--- a/src/components/ElimsRoundManagement.tsx
+++ b/src/components/ElimsRoundManagement.tsx
@@ -240,7 +240,6 @@ const ElimsRoundManagement = ({
 	};
 
 	const courseSelectors = useMemo(() => {
-		console.log('courses in courseSelectors', courses);
 		return courses.map((course, i) => {
 			return (
 				<IonSelect

--- a/src/data/courseData.ts
+++ b/src/data/courseData.ts
@@ -1,7 +1,12 @@
 import Course from "../types/Course";
 import { Platform } from "../types/Platform";
-import { switchCourseData } from "./course_data/switchCourseData";
-import wiiCourseData from "./course_data/wiiCourseData";
+import { switchCourseData, SWITCH_COURSES_ALL_MEAN, SWITCH_COURSES_ALL_STD, SWITCH_COURSES_NO_DLC_MEAN, SWITCH_COURSES_NO_DLC_STD } from "./course_data/switchCourseData";
+import wiiCourseData, { WII_COURSES_ALL_MEAN, WII_COURSES_ALL_STD }from "./course_data/wiiCourseData";
+
+const COURSE_DIFFICULTY_MIN = 1;
+const COURSE_DIFFICULTY_MAX = 5;
+const COURSE_DIFFICULTY_DEFAULT_MEAN = 3;
+const COURSE_DIFFICULTY_DEFAULT_STD = 1;
 
 const COURSE_DATA: Map<Platform, Course[]> =  new Map();
 
@@ -14,24 +19,92 @@ export function getCoursesByDifficulty(platform: Platform, threshold: number): C
   return COURSE_DATA.get(platform)!.filter((course: Course) => course.degreeOfDifficulty == threshold);
 }
 
-export function getRandomCourse(platform: Platform, threshold: number, chosenCourses?: Course[]): Course {
-  const wiiSortedCourse = getCoursesByDifficulty(platform, threshold);
+/**
+ * 
+ * returns a completely normally random course from the list of available courses. Only selects it if the difficulty of the course matches
+ * 
+ * @author Liam Seper
+ * 
+ * @param platform - the platform that the course is available on
+ * @param threshold - the difficulty of the course that will be selected is. 5 is most difficult. 1 is easiest.
+ * @param chosenCourses - the list of already chosen courses
+ * 
+ * @returns a randomly chosen course
+ */
+export function getRandomCourse(platform: Platform, chosenCourses?: Course[], DLCEnabled?: boolean): Course {
+  let threshold = getNormalThreshold(platform, DLCEnabled);
+  let coursesToChoose = getCoursesByDifficulty(platform, threshold);
+  while(coursesToChoose.length === 0) {
+    threshold = getNormalThreshold(platform, DLCEnabled)
+  }
 
-  let selectedCourse = wiiSortedCourse[Math.floor(Math.random()*wiiSortedCourse.length)]
+  let selectedCourse = coursesToChoose[Math.floor(Math.random()*coursesToChoose.length)]
 
-  if(chosenCourses != null) {
-    chosenCourses.forEach(course => {
-      while (course === selectedCourse) {
-        selectedCourse = wiiSortedCourse[Math.floor(Math.random()*wiiSortedCourse.length)]
-      }
-    });
+  if(chosenCourses && chosenCourses.length !== 1) {
+    // get a new course if it's already been chosen
+    while (chosenCourses.some(course => course.name === selectedCourse.name)) {
+      selectedCourse = coursesToChoose[Math.floor(Math.random()*coursesToChoose.length)];
+    }
   }
 
   return selectedCourse
 }
 
-export function getRandomThreshold(pseudoRandom?: () => number): number {
-  const min = 1;
-  const max = 5;
-  return Math.round(Math.random() * (max - min)) + min;
+/**
+ * a Box-Muller implementation of randomly generating a number from a normal distribution's mean and standard deviation
+ * Box-Muller method: https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
+ * 
+ * @param mean - mean of the normal distribution the number should be generated against
+ * @param std - the standard deviation of the normal distribution the number should be generated against
+ * @returns - a number randomly generated from a normal distribution of given mean and standard deviation
+ */
+function gaussianRandom(mean: number = 0, std: number = 1): number {
+  // Converts [0,1) to (0,1)
+  let u = 1 - Math.random();
+  let v = Math.random();
+  let z = Math.sqrt( -2.0 * Math.log( u ) ) * Math.cos( 2.0 * Math.PI * v );
+
+  // Transform to the desired mean and standard deviation:
+  return z * std + mean;
+}
+
+export function computeCoursesMean(courses: Course[]): number {
+  return courses.reduce((agg, curr) => agg + curr.degreeOfDifficulty, 0) / courses.length;
+}
+
+export function computeCoursesStd(courses: Course[], mean: number) {
+  const variance = courses.reduce((agg, curr) => agg + Math.pow((curr.degreeOfDifficulty - mean), 2), 0) / courses.length;
+  const std = Math.sqrt(variance);
+  return std;
+}
+
+export function getNormalThreshold(platform: Platform, DLCEnabled?: boolean): number {
+  let mean = COURSE_DIFFICULTY_DEFAULT_MEAN;
+  let std = COURSE_DIFFICULTY_DEFAULT_STD;
+
+  // assigns the appropriate mean and std given platform and courses.
+  // TODO: extrapolate to own function
+  if (platform === Platform.Switch) {
+    if (DLCEnabled) {
+      mean = SWITCH_COURSES_ALL_MEAN;
+      std = SWITCH_COURSES_ALL_STD;
+    } else {
+      mean = SWITCH_COURSES_NO_DLC_MEAN;
+      std = SWITCH_COURSES_NO_DLC_STD;
+    }
+  }
+  else if (platform === Platform.Wii) {
+    mean = WII_COURSES_ALL_MEAN;
+    std = WII_COURSES_ALL_STD;
+  }
+
+  // ensure it is within the range
+  let threshold = Math.round(gaussianRandom(mean, std));
+  // ensures threshold is in the range
+  if (threshold <= 0) {
+    threshold = COURSE_DIFFICULTY_MIN;
+  } else if (threshold > COURSE_DIFFICULTY_MAX) {
+    threshold = COURSE_DIFFICULTY_MAX;
+  }
+  return threshold;
 }

--- a/src/data/course_data/switchCourseData.ts
+++ b/src/data/course_data/switchCourseData.ts
@@ -1,6 +1,8 @@
 import Course from "../../types/Course";
 import { Platform } from "../../types/Platform";
 
+import { computeCoursesMean, computeCoursesStd } from "../courseData";
+
 export const switchCourseData: Course[] = [
     { name: "Mario Kart Stadium", degreeOfDifficulty: 1, platform: Platform.Switch },
     { name: "Water Park", degreeOfDifficulty: 2, platform: Platform.Switch },
@@ -72,3 +74,10 @@ export const switchCourseData: Course[] = [
 
   // index which DLC courses start
   export const switchDLCCutoff = 48;
+
+  export const SWITCH_COURSES_NO_DLC_MEAN = computeCoursesMean(switchCourseData.slice(0, switchDLCCutoff));
+  export const SWITCH_COURSES_NO_DLC_STD = computeCoursesStd(switchCourseData.slice(0, switchDLCCutoff), SWITCH_COURSES_NO_DLC_MEAN);
+
+  export const SWITCH_COURSES_ALL_MEAN = computeCoursesMean(switchCourseData);
+  export const SWITCH_COURSES_ALL_STD = computeCoursesStd(switchCourseData, SWITCH_COURSES_ALL_MEAN);
+

--- a/src/data/course_data/wiiCourseData.ts
+++ b/src/data/course_data/wiiCourseData.ts
@@ -1,5 +1,6 @@
 import { Platform } from "../../types/Platform";
 import Course from "../../types/Course";
+import { computeCoursesMean, computeCoursesStd } from "../courseData";
 
 const wiiCourseData: Course[] = [{
     name: "Luigi Circuit",
@@ -158,3 +159,6 @@ const wiiCourseData: Course[] = [{
   }];
 
   export default wiiCourseData;
+
+  export const WII_COURSES_ALL_MEAN = computeCoursesMean(wiiCourseData);
+  export const WII_COURSES_ALL_STD = computeCoursesStd(wiiCourseData, WII_COURSES_ALL_MEAN);

--- a/tests/algorithms.test.ts
+++ b/tests/algorithms.test.ts
@@ -4,7 +4,6 @@ import Tournament from '../src/types/Tournament';
 import Setup from '../src/types/Setup';
 import Course from '../src/types/Course';
 import { Platform } from '../src/types/Platform';
-import { getRandomThreshold } from '../src/data/courseData';
 import { range } from 'itertools';
 import { switchCourseData, switchDLCCutoff } from '../src/data/course_data/switchCourseData';
 import SeedGenerationAlgorithm from '../src/types/SeedGenerationAlgorithm.enum';
@@ -807,30 +806,7 @@ test("Test createSeedingRounds with no leftovers", () => {
     expect(setups[1].rounds[0].participants).toHaveLength(4);
 })
 
-// test("Test generateCourseSelection with random threshold 4-20", () => {
-//     const threshold
-
-//     let actualThreshold = 0
-
-//     const courses: Course[] = generateCourseSelection(Platform.Wii, threshold, 4)
-//     //have length 4
-//     expect(courses).toHaveLength(4);
-
-//     courses.forEach(element => {
-//         actualThreshold += element.degreeOfDifficulty
-//     });
-//     //difficulty is correct
-//     expect(actualThreshold).toEqual(threshold)
-
-// })
-
-test("Test getRandomThreshold", () => {
-
-    let threshold = getRandomThreshold();
-    expect(threshold).toBeLessThan(6)
-    expect(threshold).toBeGreaterThan(0)
-
-})
+// TODO: Add normal distribution tests
 
 const participants2: Participant[] = [
     { 


### PR DESCRIPTION
I added functionality to generate the difficulty threshold used to select courses for a given race to use a normal distribution according to the given course pool, instead of the previous random 1 - 5 method.

In the future, there could be an option to toggle the old legacy way (random 1 - 5) method, instead of using a normal distribution.

It is also worth noting that the distribution rounds any difficulties lower than the minimum (1) and higher than the maximum (5) to the respective cutoff (1 and 5), so it is not "truly" normal. However, the standard deviation was ~1.2 with a mean of 2.8, so this means it only increases the effects of values > 2 standard deviations away. Since 95% of values fall within 2 std devs, this only really eskews the values between +2 and +3 (5) to be generated around 1% more often. Similarly, it causes the values between -2 and -3 (1) to be generated around 1% more often. Hardly noticeable, and to be honest, maybe spices it up a bit 🥵🥵🥵